### PR TITLE
Dato

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,9 @@ npm-debug.log
 # Nuxt build
 .nuxt
 
-# Nuxt generate
+# Nuxt/DatoCMS generate
 dist
+data
+
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -2,13 +2,24 @@
 
 > World Water Atlas
 
+## Technologies
+* [Nuxt.js](https://nuxtjs.org/guide)
+* [DatoCMS](https://docs.datocms.com)
+
+## Connecting to the CMS
+
+Ask a colleague for the API key for read-access or log in to [DatoCMS](https://worldwateratlas.admin.datocms.com/admin/access_tokens), and place this in a `.env` file at the root of this project:
+```
+DATO_API_TOKEN=12300000000bb592578e78628dae95
+```
+
 ## Build Setup
 
 ``` bash
 # install dependencies
 $ npm install # Or yarn install
 
-# serve with hot reload at localhost:3000
+# serve with hot reload at localhost:9920
 $ npm run dev
 
 # build for production and launch server

--- a/dato.config.js
+++ b/dato.config.js
@@ -1,26 +1,36 @@
-const stringify = require('json-stringify-safe')
 const includeUnpublished = !!process.env.UNPUBLISHED
 
 module.exports = (dato, root, i18n) => {
-  downloadChapterMarkers(dato, root, i18n)
+  downloadGlobeMarkers(dato, root, i18n)
 }
 
-function downloadChapterMarkers (dato, root, i18n) {
-  const markers = dato.pages
+function downloadGlobeMarkers (dato, root, i18n) {
+  const markers = dato.chapters
     .filter(filterPublished)
     .map(({ entity }) => {
-      const { title, theme, location, images } = entity
-      return {
-        title,
-        theme,
-        images,
-        location: {
-          lat: location.latitude,
-          lon: location.longitude
+      const { title, pages, characterPortrait, characterName, chapterType } = entity
+      const chapterTitle = title
+
+      return pages.map((id) => {
+        const { entity } = dato.find(id)
+        const { title, location, keywords, theme } = entity
+        return {
+          title,
+          location: {
+            lat: location.latitude,
+            lon: location.longitude
+          },
+          metadata: {
+            chapter: `${chapterType}: ${chapterTitle}`,
+            keywords,
+            theme,
+            characterPortrait,
+            characterName
+          }
         }
-      }
-    })
-  root.createDataFile('data/chapterMarkers.json', 'json', markers)
+      })
+    }).reduce((a, b) => a.concat(b), []) // Flatten array by reducing to concatenated array
+  root.createDataFile('data/globeMarkers.json', 'json', markers)
 }
 
 function filterPublished (item) {

--- a/dato.config.js
+++ b/dato.config.js
@@ -1,10 +1,35 @@
+/**
+ * @typedef Dato
+ * @type {object} - DatoCMS API object
+ */
+
+/**
+ * @typedef Root
+ * @type {object} - Dato Filesystem API
+ */
+
+/**
+ * @typedef i18n
+ * @type {object}
+ * @property {string} locale - Current language in ISO 639-1
+ * @property {string[]} availableLocales - Available languages in ISO 639-1
+ */
+
 const includeUnpublished = !!process.env.UNPUBLISHED
 
 module.exports = (dato, root, i18n) => {
-  downloadGlobeMarkers(dato, root, i18n)
+  generateGlobeMarkers(dato, root, i18n)
 }
 
-function downloadGlobeMarkers (dato, root, i18n) {
+/**
+ * Write out JSON file with an array of objects based on pages from DatoCMS
+ * Used for the globe visualisation
+ *
+ * @param {Dato} dato - DatoCMS API
+ * @param {Root} root - Project root
+ * @param {i18n} i18n
+ */
+function generateGlobeMarkers (dato, root, i18n) {
   const markers = dato.chapters
     .filter(filterPublished)
     .map(({ entity }) => {
@@ -29,10 +54,17 @@ function downloadGlobeMarkers (dato, root, i18n) {
           }
         }
       })
-    }).reduce((a, b) => a.concat(b), []) // Flatten array by reducing to concatenated array
+    }).reduce((a, b) => a.concat(b), []) // Flatten array by reducing to concatenating array
   root.createDataFile('data/globeMarkers.json', 'json', markers)
 }
 
+/**
+ * filter item based on published flag,
+ * or override when UNPUBLISHED is set.
+ *
+ * @param {DatoRecord} item
+ * @returns {DatoRecord}
+ */
 function filterPublished (item) {
   if (includeUnpublished) {
     return true

--- a/dato.config.js
+++ b/dato.config.js
@@ -1,0 +1,31 @@
+const stringify = require('json-stringify-safe')
+const includeUnpublished = !!process.env.UNPUBLISHED
+
+module.exports = (dato, root, i18n) => {
+  downloadChapterMarkers(dato, root, i18n)
+}
+
+function downloadChapterMarkers (dato, root, i18n) {
+  const markers = dato.pages
+    .filter(filterPublished)
+    .map(({ entity }) => {
+      const { title, theme, location, images } = entity
+      return {
+        title,
+        theme,
+        images,
+        location: {
+          lat: location.latitude,
+          lon: location.longitude
+        }
+      }
+    })
+  root.createDataFile('data/chapterMarkers.json', 'json', markers)
+}
+
+function filterPublished (item) {
+  if (includeUnpublished) {
+    return true
+  }
+  return item.published
+}

--- a/dato.config.js
+++ b/dato.config.js
@@ -16,10 +16,20 @@
  */
 
 const includeUnpublished = !!process.env.UNPUBLISHED
+const exportScope = process.env.DATO_EXPORT
 
 module.exports = (dato, root, i18n) => {
-  generateGlobeMarkers(dato, root, i18n)
-  generateChapters(dato, root, i18n)
+  switch (exportScope) {
+    case 'globe':
+      generateGlobeMarkers(dato, root, i18n)
+      break
+    case 'chapters':
+      generateChapters(dato, root, i18n)
+      break
+    default:
+      generateGlobeMarkers(dato, root, i18n)
+      generateChapters(dato, root, i18n)
+  }
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,6 +162,24 @@
         }
       }
     },
+    "agent-base": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.1",
+        "semver": "5.0.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        }
+      }
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -1543,6 +1561,37 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
     },
+    "bl": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -2022,9 +2071,9 @@
       }
     },
     "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.1.tgz",
+      "integrity": "sha512-UjgcRlTAhAkLeXmDe2wK7ktwy/tgAqxiSndTIPiFZuIPLZmzHzWMwUIe9h9m/OokypG7snxCDEuwJshGBdPvaw==",
       "dev": true
     },
     "clap": {
@@ -3028,6 +3077,410 @@
         "time-zone": "1.0.0"
       }
     },
+    "datocms-client": {
+      "version": "0.3.41",
+      "resolved": "https://registry.npmjs.org/datocms-client/-/datocms-client-0.3.41.tgz",
+      "integrity": "sha1-ZT+Nk19ao00rz39KPG7lVI7WNZQ=",
+      "dev": true,
+      "requires": {
+        "babel-polyfill": "6.16.0",
+        "chokidar": "1.7.0",
+        "core-js": "2.4.1",
+        "denodeify": "1.2.1",
+        "docopt": "0.6.2",
+        "dotenv": "2.0.0",
+        "https-proxy-agent": "1.0.0",
+        "humps": "1.1.0",
+        "js-yaml": "3.6.1",
+        "mkdirp": "0.5.1",
+        "node-fetch": "1.6.3",
+        "ora": "0.4.1",
+        "pluralize": "3.0.0",
+        "pretty-error": "2.0.1",
+        "pusher-js": "4.2.2",
+        "query-string": "4.2.3",
+        "request": "2.75.0",
+        "rimraf": "2.5.4",
+        "speakingurl": "10.0.0",
+        "tmp": "0.0.29",
+        "toml-js": "0.0.8",
+        "traverse": "0.6.6",
+        "whatwg-fetch": "1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "anymatch": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+          "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+          "dev": true,
+          "requires": {
+            "micromatch": "2.3.11",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true
+        },
+        "babel-polyfill": {
+          "version": "6.16.0",
+          "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.16.0.tgz",
+          "integrity": "sha1-LUUCHfh+JqN0ttTRqcZZZNF/JCI=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.9.6"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+          "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+          "dev": true,
+          "requires": {
+            "anymatch": "1.3.2",
+            "async-each": "1.0.1",
+            "fsevents": "1.1.3",
+            "glob-parent": "2.0.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "2.0.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0"
+          }
+        },
+        "core-js": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "form-data": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
+          "integrity": "sha1-bwrrrcxdoWwT4ezBETfYX5uIOyU=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.12.2",
+            "is-my-json-valid": "2.17.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "2.7.3"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        },
+        "pluralize": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-3.0.0.tgz",
+          "integrity": "sha1-cnmanvQaU/8MA95lIuKGtA1cky0=",
+          "dev": true
+        },
+        "pretty-error": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.0.1.tgz",
+          "integrity": "sha1-inN1uf4m5DtRAXlOTb6sNiqNYpo=",
+          "dev": true,
+          "requires": {
+            "renderkid": "2.0.1",
+            "utila": "0.4.0"
+          }
+        },
+        "qs": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+          "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
+          "dev": true
+        },
+        "query-string": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.2.3.tgz",
+          "integrity": "sha1-nycnPSB6JajuTHuMdNzUXVVtuCI=",
+          "dev": true,
+          "requires": {
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
+          "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.75.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
+          "integrity": "sha1-0rgmiihtoT6qXQGt9dGMyQ9lfZM=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "bl": "1.1.2",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.0.0",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.8.2",
+            "qs": "6.2.3",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.4.3"
+          }
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "tmp": {
+          "version": "0.0.29",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "dev": true
+        }
+      }
+    },
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -3125,6 +3578,12 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "denodeify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
+      "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
+      "dev": true
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -3161,6 +3620,12 @@
         "miller-rabin": "4.0.1",
         "randombytes": "2.0.6"
       }
+    },
+    "docopt": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz",
+      "integrity": "sha1-so6eIiDaXsSffqW7JKR3h0Be6xE=",
+      "dev": true
     },
     "doctrine": {
       "version": "2.1.0",
@@ -3243,6 +3708,12 @@
       "requires": {
         "is-obj": "1.0.1"
       }
+    },
+    "dotenv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
+      "integrity": "sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk=",
+      "dev": true
     },
     "duplexer": {
       "version": "0.1.1",
@@ -4219,6 +4690,15 @@
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
       "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
     },
+    "faye-websocket": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz",
+      "integrity": "sha1-iFk0x57/sECVSeDAo4Ae0XpAza0=",
+      "dev": true,
+      "requires": {
+        "websocket-driver": "0.7.0"
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -4319,6 +4799,14 @@
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
+      },
+      "dependencies": {
+        "circular-json": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+          "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+          "dev": true
+        }
       }
     },
     "flatten": {
@@ -5383,6 +5871,21 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -5881,6 +6384,12 @@
         }
       }
     },
+    "http-parser-js": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
+      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
+      "dev": true
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -5896,6 +6405,28 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+    },
+    "https-proxy-agent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "dev": true,
+      "requires": {
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "hullabaloo-config-manager": {
       "version": "1.1.1",
@@ -5926,6 +6457,12 @@
           "dev": true
         }
       }
+    },
+    "humps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/humps/-/humps-1.1.0.tgz",
+      "integrity": "sha1-maBcyAsTrnVKPR4akhgvJx7x2Y8=",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -6234,6 +6771,18 @@
         "is-path-inside": "1.0.1"
       }
     },
+    "is-my-json-valid": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -6332,6 +6881,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -6534,6 +7089,12 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -7760,6 +8321,54 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
+      }
+    },
+    "ora": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.4.1.tgz",
+      "integrity": "sha1-4mgYfIiQKV94WaxTX9jKLA/2Tec=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "2.1.0",
+        "cli-spinners": "1.1.0",
+        "log-symbols": "1.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
@@ -10453,6 +11062,16 @@
         "minimist": "1.2.0"
       }
     },
+    "pusher-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-4.2.2.tgz",
+      "integrity": "sha512-EjFE+PAC6lG7Ap3fhU7c2NyVul6DghNlEbiJVkcTca182U3b7iYgiQY8sQu9FCl5YmnOZ2L95RVYT9JM+YX9jQ==",
+      "dev": true,
+      "requires": {
+        "faye-websocket": "0.9.4",
+        "xmlhttprequest": "1.8.0"
+      }
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -11362,6 +11981,12 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
+    "speakingurl": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-10.0.0.tgz",
+      "integrity": "sha1-JO+YDehRlNF/La6jCmssLMURFbs=",
+      "dev": true
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -11933,6 +12558,12 @@
         "repeat-string": "1.6.1"
       }
     },
+    "toml-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/toml-js/-/toml-js-0.0.8.tgz",
+      "integrity": "sha1-ZI6m8aTWOxnAuzC47QPkDQlHOwo=",
+      "dev": true
+    },
     "toposort": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
@@ -11963,6 +12594,12 @@
           "dev": true
         }
       }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -12888,6 +13525,22 @@
         "source-map": "0.6.1"
       }
     },
+    "websocket-driver": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "dev": true,
+      "requires": {
+        "http-parser-js": "0.4.9",
+        "websocket-extensions": "0.1.3"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "dev": true
+    },
     "well-known-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
@@ -12902,6 +13555,12 @@
       "requires": {
         "iconv-lite": "0.4.19"
       }
+    },
+    "whatwg-fetch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz",
+      "integrity": "sha1-AcKsTfQOI2qqGEgOO+dL1cjreY4=",
+      "dev": true
     },
     "whatwg-url": {
       "version": "6.4.0",
@@ -13091,6 +13750,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+      "dev": true
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "deploy": "push-dir --dir=dist --branch=gh-pages --cleanup",
     "data:dev": "cross-env UNPUBLISHED=1 dato dump",
     "data:build": "dato dump",
+    "data:globe": "cross-env DATO_EXPORT=globe dato dump",
+    "data:chapters": "cross-env DATO_EXPORT=chapters dato dump",
     "test": "ava"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "author": "Fedor Baart <fedor.baart@deltares.nl>",
   "private": true,
   "scripts": {
+    "predev": "npm run data:dev",
     "dev": "nuxt",
+    "prebuild": "npm run data:build",
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",
@@ -14,6 +16,8 @@
     "build:gh-pages": "cross-env DEPLOY_ENV=GH_PAGES nuxt build",
     "generate:gh-pages": "cross-env DEPLOY_ENV=GH_PAGES nuxt generate",
     "deploy": "push-dir --dir=dist --branch=gh-pages --cleanup",
+    "data:dev": "cross-env UNPUBLISHED=1 dato dump",
+    "data:build": "dato dump",
     "test": "ava"
   },
   "config": {
@@ -37,7 +41,10 @@
   "devDependencies": {
     "ava": "0.24.0",
     "babel-eslint": "^7.2.3",
+    "circular-json": "0.5.1",
     "cross-env": "^5.1.3",
+    "dato": "1.0.5",
+    "datocms-client": "0.3.41",
     "eslint": "^4.3.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-loader": "^1.9.0",
@@ -48,6 +55,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "gh-pages": "^1.1.0",
     "jsdom": "11.5.1",
+    "json-stringify-safe": "5.0.1",
     "postcss": "^6.0.16",
     "postcss-hexrgba": "^1.0.0",
     "postcss-nested": "^3.0.0",


### PR DESCRIPTION
Added DatoCMS integration

Functions to fetch data from Dato are defined in dato.config.js. 

`npm run data:dev` runs the dato.config.js scripts on **all** content,
`npm run data:build` runs the dato.config.js scripts on **published** content
`npm run data:globe` runs the dato.config.js `generateGlobeMarkers` function,
`npm run data:chapters` runs the dato.config.js `generateChapters` function

@janwillemtulp The file globeMarkers.json ought to be a *near* drop-in replacement for your current json. 