### PR TITLE
override history with last url path

### DIFF
--- a/pages/narratives/_book/_chapter/_page.vue
+++ b/pages/narratives/_book/_chapter/_page.vue
@@ -47,7 +47,7 @@ export default {
             const page = entry.target.id
             const path = `/narratives/${book}/${chapter}/${page}`
             if (path !== window.location.pathname) {
-              history.pushState({}, page, path)
+              history.replaceState({}, page, path)
             }
             break
           }


### PR DESCRIPTION
instead of pushState, use replaceState, so that the back button goes to the chapter instead of the last scrolled article