### PR TITLE
fix(globe): add base to marker links

### DIFF
--- a/components/globe-component/globe-component.js
+++ b/components/globe-component/globe-component.js
@@ -196,8 +196,10 @@ export default {
     handleClick (event) {
       if (this.intersections.length > 0) {
         const { data } = this.intersections[0].object
-        // navigate to path
-        this.$router.push(data.path)
+        const { base = '/' } = this.$router.options.base
+        const pathWithoutleadingSlash = data.path.replace(/^\//g, '');
+        const path = `${base}${pathWithoutleadingSlash}`
+        this.$router.push(path)
       }
     },
     handleMouseMove (event) {

--- a/components/globe-component/globe-component.js
+++ b/components/globe-component/globe-component.js
@@ -197,7 +197,7 @@ export default {
       if (this.intersections.length > 0) {
         const { data } = this.intersections[0].object
         const { base = '/' } = this.$router.options.base
-        const pathWithoutleadingSlash = data.path.replace(/^\//g, '');
+        const pathWithoutleadingSlash = data.path.replace(/^\//g, '')
         const path = `${base}${pathWithoutleadingSlash}`
         this.$router.push(path)
       }


### PR DESCRIPTION
When the globe is deployed on github the markers on the globe won't navigate to the pages because wwa is missing.