### PR TITLE
fix(home): move home button z-index up

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -45,6 +45,7 @@ main {
   right: 0;
   top: 0;
   color: var(--ui--text--invert);
+  z-index: 1;
 }
 .link-menu a:not(.home) {
   float: right;


### PR DESCRIPTION
Currently, you cannot click the home button because it's overlapped by the main content.