### PR TITLE
chore: tweak Nuxt & Netlify for faster builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,7 @@
   command = "npm run lint && npm run build && npm run generate"
   publish = "dist/"
   [build.environment]
+    CI = "1"                          # https://www.voorhoede.nl/en/blog/10x-faster-nuxt-builds-on-netlify/#skip-streaming-logs
     NODE_VERSION = "12"
     NODE_ENV = "development"
     NPM_CONFIG_AUDIT = "false"

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -101,6 +101,21 @@ module.exports = {
   },
 
   build: {
+    html: {
+      // disable minify CSS and JS to improve build times
+      // see: https://www.voorhoede.nl/en/blog/10x-faster-nuxt-builds-on-netlify/#optimise-html-minification
+      minify: {
+        collapseBooleanAttributes: true,
+        decodeEntities: true,
+        minifyCSS: false,
+        minifyJS: false,
+        processConditionalComments: true,
+        removeEmptyAttributes: true,
+        removeRedundantAttributes: true,
+        trimCustomFragments: true,
+        useShortDoctype: true
+      }
+    },
     extend (config, context) {
       if (context.isDev && context.isClient) {
         config.module.rules.push({


### PR DESCRIPTION
using tips from https://www.voorhoede.nl/en/blog/10x-faster-nuxt-builds-on-netlify/

Local results:

Build time before: 161.4375s
Build time after: 28.7774s

**That's about ~6x faster**

In Netlify deploy log I see total deploy times become 3 to 4x faster. Is less than local, but that's because there's more happening in a Netlify deploy than just a build.