### PR TITLE
Use media query variables for consistent breakpoints

### DIFF
--- a/components/app-description/AppDescription.vue
+++ b/components/app-description/AppDescription.vue
@@ -22,7 +22,7 @@ export default {
   font-weight: bold;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .app-description {
     font-size: .875rem;
     font-weight: normal;

--- a/components/app-footer/AppFooter.vue
+++ b/components/app-footer/AppFooter.vue
@@ -92,7 +92,7 @@ export default {
   color: var(--white);
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .app-footer__logo {
     margin-bottom: 1.5rem;
   }
@@ -102,7 +102,7 @@ export default {
   color: var(--tertiary-blue);
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .app-footer__logo-highlight {
     display: block;
   }
@@ -114,7 +114,7 @@ export default {
   font-weight: bold;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .app-footer__navigation {
     float: right;
     display: flex;

--- a/components/book-list/BookList.vue
+++ b/components/book-list/BookList.vue
@@ -113,7 +113,7 @@ export default {
   color: var(--primary-blue);
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .book-list__book-title {
     font-size: 2rem;
     line-height: 2.25rem;

--- a/components/chapter-list/ChapterList.vue
+++ b/components/chapter-list/ChapterList.vue
@@ -233,7 +233,7 @@ export default {
   hyphens: auto;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .chapter-list {
     margin: 0 -6px;
   }
@@ -273,7 +273,7 @@ export default {
   }
 }
 
-@media (min-width: 768px) {
+@media (--md-viewport) {
   .chapter-list__item-content {
     word-break: normal;
   }

--- a/components/core/index.css
+++ b/components/core/index.css
@@ -13,6 +13,11 @@
   --globe-spacing-tall--desktop: 85vh;
 }
 
+@custom-media --sm-viewport (min-width: 37.5em);
+@custom-media --md-viewport (min-width: 48em);
+@custom-media --lg-viewport (min-width: 64em);
+@custom-media --xl-viewport (min-width: 90em);
+
 .layout--static-page {
   width: 100%;
   background-color: var(--white);
@@ -34,7 +39,7 @@
   z-index: 1;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .layout-section {
     padding: 0 40px;
   }

--- a/components/event-banner/EventBanner.vue
+++ b/components/event-banner/EventBanner.vue
@@ -40,7 +40,7 @@
     margin-bottom: 2rem;
   }
 
-  @media (min-width: 600px) {
+  @media (--sm-viewport) {
     .event-banner {
       margin-bottom: 3rem;
     }
@@ -57,7 +57,7 @@
     border-radius: 5px;
   }
 
-  @media (min-width: 600px) {
+  @media (--sm-viewport) {
     .event-banner__banner {
       margin-bottom: 1rem;
       padding: 6rem 2rem;
@@ -65,7 +65,7 @@
     }
   }
 
-  @media (min-width: 1024px) {
+  @media (--lg-viewport) {
     .event-banner__banner {
       background-position: bottom 20% center;
     }
@@ -76,7 +76,7 @@
     font-weight: bold;
   }
 
-  @media (min-width: 600px) {
+  @media (--sm-viewport) {
     .event-banner__title {
       font-size: 3.75rem;
       font-weight: 900;
@@ -88,7 +88,7 @@
     font-weight: 500;
   }
 
-  @media (min-width: 600px) {
+  @media (--sm-viewport) {
     .event-banner__date {
       font-size: 2rem;
       font-weight: bold;

--- a/components/event-header/EventHeader.vue
+++ b/components/event-header/EventHeader.vue
@@ -60,7 +60,7 @@
     background-color: var(--primary-blue);
   }
 
-  @media (min-width: 600px) {
+  @media (--sm-viewport) {
     .event-header {
       padding: 1rem 0;
     }
@@ -72,7 +72,7 @@
     border-radius: 50%;
   }
 
-  @media (min-width: 600px) {
+  @media (--sm-viewport) {
     .event-header__image {
       margin-right: 1rem;
     }
@@ -85,7 +85,7 @@
     font-size: 1rem;
   }
 
-  @media (min-width: 600px) {
+  @media (--sm-viewport) {
     .event-header__name {
       flex-direction: row;
     }
@@ -96,7 +96,7 @@
     color: var(--tertiary-blue);
   }
 
-  @media (min-width: 600px) {
+  @media (--sm-viewport) {
     .event-header__location {
       margin-right: 0.4rem;
     }

--- a/components/filter-keywords/FilterKeywords.vue
+++ b/components/filter-keywords/FilterKeywords.vue
@@ -75,7 +75,7 @@ export default {
   margin: 1rem 0;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .filter-keywords {
     width: calc(100vw - 80px);
     padding: 0 40px;

--- a/components/filter-tag/FilterTag.vue
+++ b/components/filter-tag/FilterTag.vue
@@ -43,7 +43,7 @@ export default {
   color: var(--white);
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .filter-tag {
     font-size: 1rem;
   }

--- a/components/globe-header/GlobeHeader.vue
+++ b/components/globe-header/GlobeHeader.vue
@@ -40,7 +40,7 @@ export default {
   max-width: 290px;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .globe-header {
     top: 5rem;
   }

--- a/components/globe-navigation/GlobeNavigation.vue
+++ b/components/globe-navigation/GlobeNavigation.vue
@@ -230,7 +230,7 @@ li.globe-navigation__tab--selected {
   text-decoration: none;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .globe-navigation__tab-link {
     font-size: 1.25rem;
   }
@@ -253,7 +253,7 @@ li.globe-navigation__tag {
   margin-bottom: .5rem;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   li.globe-navigation__tag {
     margin-right: .75rem;
     margin-bottom: .75rem;
@@ -274,7 +274,7 @@ li.globe-navigation__tag {
   margin-bottom: 0;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .globe-navigation__description {
     max-width: 66%;
   }

--- a/components/main-menu/MainMenu.vue
+++ b/components/main-menu/MainMenu.vue
@@ -78,7 +78,7 @@ export default {
   line-height: 1.2;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .main-menu__logo {
     font-size: 1.3rem;
   }
@@ -88,7 +88,7 @@ export default {
   display: none;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .main-menu__description {
     display: block;
     flex: 0 1 300px;
@@ -108,7 +108,7 @@ export default {
   text-transform: uppercase;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .main-menu__navigation {
     flex: 0 0 auto;
     flex-wrap: nowrap;

--- a/components/narrative-footer/NarrativeFooter.vue
+++ b/components/narrative-footer/NarrativeFooter.vue
@@ -202,7 +202,7 @@ export default {
   text-decoration: underline;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .narrative-footer__related-item {
     width: 48%;
   }

--- a/components/narrative-header/NarrativeHeader.vue
+++ b/components/narrative-header/NarrativeHeader.vue
@@ -148,7 +148,7 @@ export default {
   transition: transform var(--narrative-header-transition-speed) var(--narrative-header-transition-timing-hide);
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .narrative-header__content {
     padding: 3.75rem 2.5rem;
   }
@@ -208,7 +208,7 @@ export default {
   width: 1em;
 }
 
-@media (min-width: 768px) {
+@media (--md-viewport) {
   .narrative-header__title {
     font-size: 2rem;
     line-height: 2.5rem;
@@ -276,7 +276,7 @@ export default {
   overflow: scroll;
 }
 
-@media (min-width: 768px) {
+@media (--md-viewport) {
   .narrative-header__navigation {
     max-width: 600px;
   }
@@ -332,19 +332,19 @@ export default {
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .narrative-header--condensed {
     top: 5rem;
   }
 }
 
-@media (min-width: 1024px) {
+@media (--lg-viewport) {
   .narrative-header--condensed {
     width: 67vw;
   }
 }
 
-@media (min-width: 1440px) {
+@media (--xl-viewport) {
   .narrative-header--condensed {
     width: 50vw;
   }

--- a/components/page-body-title/PageBodyTitle.vue
+++ b/components/page-body-title/PageBodyTitle.vue
@@ -116,7 +116,7 @@ export default {
   margin-bottom: .5rem;
 }
 
-@media (min-width: 768px) {
+@media (--md-viewport) {
   .page-body-title__title {
     font-size: 2rem;
     line-height: 2.5rem;
@@ -147,7 +147,7 @@ export default {
   margin-bottom: 0.5rem;
 }
 
-@media only screen and (min-width: 600px) {
+@media only screen and (--sm-viewport) {
   .page-body-title__theme {
     margin-bottom: 0;
   }

--- a/components/page-body/PageBody.vue
+++ b/components/page-body/PageBody.vue
@@ -176,7 +176,7 @@ export default {
   margin-bottom: 1rem;
 }
 
-@media only screen and (min-width: 600px) {
+@media only screen and (--sm-viewport) {
   .page-body {
     padding: 1rem 2.5rem;
   }
@@ -213,7 +213,7 @@ export default {
   margin: 0 auto;
 }
 
-@media only screen and (min-width: 600px) {
+@media only screen and (--sm-viewport) {
   .page-body__asset-placeholder {
     padding: 0.5rem 2.5rem 1rem 2.5rem;
   }

--- a/components/page-component/PageComponent.vue
+++ b/components/page-component/PageComponent.vue
@@ -39,7 +39,7 @@ export default {
   margin: 3rem auto 0 auto;
 }
 
-@media only screen and (min-width: 600px) {
+@media only screen and (--sm-viewport) {
   .page-component {
     margin: 3.75rem auto 0 auto;
     padding-left: 2rem;

--- a/components/vimeo-embed/VimeoEmbed.vue
+++ b/components/vimeo-embed/VimeoEmbed.vue
@@ -77,7 +77,7 @@ export default {
   margin-bottom: 0.5rem;
 }
 
-@media (min-width: 600px) and (max-width: 900px) {
+@media (--sm-viewport) and (max-width: 900px) {
   .vimeo-embed__title {
     height: 3.25rem;
     line-height: 1.625rem;

--- a/layouts/globe.vue
+++ b/layouts/globe.vue
@@ -81,7 +81,7 @@ export default {
   top: 9rem;
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .globe-component {
     top: 0rem;
   }
@@ -100,7 +100,7 @@ export default {
   margin-top: var(--globe-spacing-tall);
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .globe-spacing {
     margin-top: var(--globe-spacing-default--desktop);
   }
@@ -110,13 +110,13 @@ export default {
   }
 }
 
-@media (min-width: 1024px) {
+@media (--lg-viewport) {
 .globe-component--right {
     transform: translateX(33%);
   }
 }
 
-@media (min-width: 1440px) {
+@media (--xl-viewport) {
   .globe-component--right {
     transform: translateX(25%);
   }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -77,7 +77,7 @@ const mapallInternalEventsToRoutes = (allInternalEvents) => (
 
 const postcss = {
   plugins: {
-    'postcss-import': {},
+    'postcss-custom-media': {},
     'postcss-calc': {},
     'postcss-custom-properties': {},
   },

--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^7.0.30",
     "postcss-calc": "^7.0.2",
+    "postcss-custom-media": "^7.0.8",
     "postcss-custom-properties": "^9.1.1",
-    "postcss-import": "^12.0.1",
     "slug": "^2.1.1",
     "webpack-glsl-loader": "^1.0.1"
   }

--- a/pages/narratives/_book/_chapter/index.vue
+++ b/pages/narratives/_book/_chapter/index.vue
@@ -167,7 +167,7 @@ export default {
   margin-top: calc(-1 * var(--globe-spacing-tall));
 }
 
-@media (min-width: 600px) {
+@media (--sm-viewport) {
   .chapter-column {
     margin-top: calc(-1 * var(--globe-spacing-default--desktop));
   }
@@ -177,13 +177,13 @@ export default {
   }
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (--lg-viewport) {
   .chapter-column {
     width: 67vw;
   }
 }
 
-@media only screen and (min-width: 1440px) {
+@media only screen and (--xl-viewport) {
   .chapter-column {
     width: 50vw;
   }
@@ -200,7 +200,7 @@ export default {
   z-index: 1;
 }
 
-@media (min-width: 768px) {
+@media (--md-viewport) {
   [data-scrolled-to-top-trigger] {
     top: calc(12.5rem + 1px);
   }


### PR DESCRIPTION
Replace hardcoded media queries, did a regex find and replace:
`600px` > `--sm-viewport`
`768px`  > `--md-viewport`
`1024px` > `--lg-viewport`
`1440px` > `--xl-viewport`