### PR TITLE
Feat: qq video embed (working)

### DIFF
--- a/pages/qq-videos.vue
+++ b/pages/qq-videos.vue
@@ -2,11 +2,11 @@
 <template>
   <div style="padding:1rem">
     <h1>qq videos</h1>
-    <a href="https://v.qq.com/x/page/a0787rl8q8p.html">demo video</a>
+    <a href="https://v.qq.com/x/page/n31074rhp1h.html">demo video</a>
 
     <h2>Iframe</h2>
     <iframe
-      src="https://v.qq.com/txp/iframe/player.html?vid=a0787rl8q8p"
+      src="https://v.qq.com/txp/iframe/player.html?vid=n31074rhp1h"
       allowFullScreen="true"
       frameborder="1"
       width="500px"

--- a/pages/qq-videos.vue
+++ b/pages/qq-videos.vue
@@ -1,0 +1,17 @@
+/* eslint-disable vue/no-parsing-error */
+<template>
+  <div style="padding:1rem">
+    <h1>qq videos</h1>
+    <a href="https://v.qq.com/x/page/a0787rl8q8p.html">demo video</a>
+
+    <h2>Iframe</h2>
+    <iframe
+      src="https://v.qq.com/txp/iframe/player.html?vid=a0787rl8q8p"
+      allowFullScreen="true"
+      frameborder="1"
+      width="500px"
+      height="300px"
+      style="background:white;"
+    />
+  </div>
+</template>


### PR DESCRIPTION
Working preview: https://deploy-preview-183--wwa.netlify.app/qq-videos/

**Background**

Design Society has embedded videos using QQ: http://www.designsociety.cn/en/index/about/design-society

QQ has iframe embed option:
![Screen Shot 2020-06-26 at 14 15 10](https://user-images.githubusercontent.com/1516059/85856422-48b66580-b7b8-11ea-93c7-d2d56b1c65f7.jpg)

Which actually works:
![Screen Shot 2020-06-26 at 14 21 26](https://user-images.githubusercontent.com/1516059/85856471-5b309f00-b7b8-11ea-8ffe-0c9e106bbc25.jpg)

And the good thing is that the video ID in the URL matches the ID in the iframe src. So we can easily construct the iframes. For example `https://v.qq.com/x/page/`**`a0787rl8q8p`**`.html` matches `<iframe src="https://v.qq.com/txp/iframe/player.html?vid=`**`a0787rl8q8p`**`" />`